### PR TITLE
Fix Swift tools version spelling in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
I am some times getting the following error in a different project that uses this package as a dependency.

 ![Screenshot 2025-04-29 at 13 17 09](https://github.com/user-attachments/assets/da4ed335-e203-42b1-ab33-2a71811515c5)

I think the correct spelling for the intended version should be "6.**0**"